### PR TITLE
AL-248: Added Nested Card result section

### DIFF
--- a/assemblyline_result_sample_service/result_sample.py
+++ b/assemblyline_result_sample_service/result_sample.py
@@ -213,44 +213,52 @@ class ResultSample(ServiceBase):
 
             # ==================================================================
             # NESTED_CARDS section:
-            #     This section allows the service writer to list a bunch of dictionary objects that have nested lists of dictionaries
-            #     to be displayed in the UI. Each dictionary object represents a process, and therefore each dictionary
-            #     must have be of the following format:
+            #     This section allows the service writer to list a bunch of dictionary objects that have nested lists
+            #     of dictionaries to be displayed in the UI. Each dictionary object represents a process, and therefore
+            #     each dictionary must have be of the following format:
             #     {
+            #       "process_pid": str,
             #       "process_name": str,
             #       "command_line": str,
-            #       "children": [] NB: This list either is empty or contains more dictionaries that have the same structure
+            #       "children": [] NB: This list either is empty or contains more dictionaries that have the same
+            #                          structure
             #     }
             nc_body = [
                 {
-                    "process_name": "(123) evil.exe",
+                    "process_pid": 123,
+                    "process_name": "evil.exe",
                     "command_line": "C:\\evil.exe",
                     "children": [
                         {
-                            "process_name": "(321) takeovercomputer.exe",
+                            "process_pid": 321,
+                            "process_name": "takeovercomputer.exe",
                             "command_line": "C:\\Temp\\takeovercomputer.exe -f do_bad_stuff",
                             "children": [
                                 {
-                                    "process_name": "(456) evenworsethanbefore.exe",
+                                    "process_pid": 456,
+                                    "process_name": "evenworsethanbefore.exe",
                                     "command_line": "C:\\Temp\\evenworsethanbefore.exe -f change_reg_key_cuz_im_bad",
                                     "children": []
                                 },
                                 {
-                                    "process_name": "(234) badfile.exe",
+                                    "process_pid": 234,
+                                    "process_name": "badfile.exe",
                                     "command_line": "C:\\badfile.exe -k nothing_to_see_here",
                                     "children": []
                                 }
                             ]
                         },
                         {
-                            "process_name": "(345) benignexe.exe",
+                            "process_pid": 345,
+                            "process_name": "benignexe.exe",
                             "command_line": "C:\\benignexe.exe -f \"just kidding, i'm evil\"",
                             "children": []
                         }
                     ]
                 },
                 {
-                    "process_name": "(987) runzeroday.exe",
+                    "process_pid": 987,
+                    "process_name": "runzeroday.exe",
                     "command_line": "C:\\runzeroday.exe -f insert_bad_spelling",
                     "children": []
                 }

--- a/assemblyline_result_sample_service/result_sample.py
+++ b/assemblyline_result_sample_service/result_sample.py
@@ -212,7 +212,7 @@ class ResultSample(ServiceBase):
             result.add_section(json_section)
 
             # ==================================================================
-            # NESTED_CARDS section:
+            # PROCESS_TREE section:
             #     This section allows the service writer to list a bunch of dictionary objects that have nested lists
             #     of dictionaries to be displayed in the UI. Each dictionary object represents a process, and therefore
             #     each dictionary must have be of the following format:
@@ -263,8 +263,8 @@ class ResultSample(ServiceBase):
                     "children": []
                 }
             ]
-            nc_section = ResultSection('Example of a NESTED_CARDS section',
-                                       body_format=BODY_FORMAT.NESTED_CARDS,
+            nc_section = ResultSection('Example of a PROCESS_TREE section',
+                                       body_format=BODY_FORMAT.PROCESS_TREE,
                                        body=json.dumps(nc_body))
             result.add_section(nc_section)
             

--- a/assemblyline_result_sample_service/result_sample.py
+++ b/assemblyline_result_sample_service/result_sample.py
@@ -214,45 +214,50 @@ class ResultSample(ServiceBase):
             # ==================================================================
             # NESTED_CARDS section:
             #     This section allows the service writer to list a bunch of dictionary objects that have nested lists of dictionaries
-            #     to be displayed in the UI
-            #     The body argument must be a list of dictionaries that have nested lists of dictionaries within them.
+            #     to be displayed in the UI. Each dictionary object represents a process, and therefore each dictionary
+            #     must have be of the following format:
+            #     {
+            #       "process_name": str,
+            #       "command_line": str,
+            #       "children": [] NB: This list either is empty or contains more dictionaries that have the same structure
+            #     }
             nc_body = [
                 {
-                    'process_name': '(123) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
-                    'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
-                    'children': [
+                    "process_name": "(123) evil.exe",
+                    "command_line": "C:\\evil.exe",
+                    "children": [
                         {
-                            'process_name': '(1234) installutil.exe',
-                            'command_line': '\"C:\\\\Windows\\\\Microsoft.NET\\\\Framework\\\\v4.0.30319\\\\installutil.exe /logtoconsole=false /logfile= /u \"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe\"\\',
-                            'children': [
+                            "process_name": "(321) takeovercomputer.exe",
+                            "command_line": "C:\\Temp\\takeovercomputer.exe -f do_bad_stuff",
+                            "children": [
                                 {
-                                    'process_name': '(1234) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
-                                    'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe\"\\',
-                                    'children': []
+                                    "process_name": "(456) evenworsethanbefore.exe",
+                                    "command_line": "C:\\Temp\\evenworsethanbefore.exe -f change_reg_key_cuz_im_bad",
+                                    "children": []
                                 },
                                 {
-                                    'process_name': '(123) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
-                                    'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe\"\\',
-                                    'children': []
+                                    "process_name": "(234) badfile.exe",
+                                    "command_line": "C:\\badfile.exe -k nothing_to_see_here",
+                                    "children": []
                                 }
                             ]
                         },
                         {
-                            'process_name': '(123) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
-                            'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe\"\\',
-                            'children': []
+                            "process_name": "(345) benignexe.exe",
+                            "command_line": "C:\\benignexe.exe -f \"just kidding, i'm evil\"",
+                            "children": []
                         }
                     ]
                 },
                 {
-                    'process_name': '(123) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
-                    'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
-                    'children': []
+                    "process_name": "(987) runzeroday.exe",
+                    "command_line": "C:\\runzeroday.exe -f insert_bad_spelling",
+                    "children": []
                 }
             ]
             nc_section = ResultSection('Example of a NESTED_CARDS section',
                                        body_format=BODY_FORMAT.NESTED_CARDS,
-                                       body=nc_body)
+                                       body=json.dumps(nc_body))
             result.add_section(nc_section)
 
             # ==================================================================

--- a/assemblyline_result_sample_service/result_sample.py
+++ b/assemblyline_result_sample_service/result_sample.py
@@ -212,6 +212,50 @@ class ResultSample(ServiceBase):
             result.add_section(json_section)
 
             # ==================================================================
+            # NESTED_CARDS section:
+            #     This section allows the service writer to list a bunch of dictionary objects that have nested lists of dictionaries
+            #     to be displayed in the UI
+            #     The body argument must be a list of dictionaries that have nested lists of dictionaries within them.
+            nc_body = [
+                {
+                    'process_name': '(123) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
+                    'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
+                    'children': [
+                        {
+                            'process_name': '(1234) installutil.exe',
+                            'command_line': '\"C:\\\\Windows\\\\Microsoft.NET\\\\Framework\\\\v4.0.30319\\\\installutil.exe /logtoconsole=false /logfile= /u \"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe\"\\',
+                            'children': [
+                                {
+                                    'process_name': '(1234) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
+                                    'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe\"\\',
+                                    'children': []
+                                },
+                                {
+                                    'process_name': '(123) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
+                                    'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe\"\\',
+                                    'children': []
+                                }
+                            ]
+                        },
+                        {
+                            'process_name': '(123) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
+                            'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe\"\\',
+                            'children': []
+                        }
+                    ]
+                },
+                {
+                    'process_name': '(123) 3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
+                    'command_line': '\"C:\\\\Users\\\\buddy\\\\AppData\\\\Local\\\\Temp\\\\3aecdd0453bf5ab10c6406193026eef8be49114135101dfc92d7d4e9aaec609d.exe',
+                    'children': []
+                }
+            ]
+            nc_section = ResultSection('Example of a NESTED_CARDS section',
+                                       body_format=BODY_FORMAT.NESTED_CARDS,
+                                       body=nc_body)
+            result.add_section(nc_section)
+
+            # ==================================================================
             # Re-Submitting files to the system
             #     Adding extracted files will have them resubmitted to the system for analysis
 

--- a/assemblyline_v4_service/common/result.py
+++ b/assemblyline_v4_service/common/result.py
@@ -24,6 +24,7 @@ BODY_FORMAT = StringTable('BODY_FORMAT', [
     ('URL', 3),
     ('JSON', 4),
     ('KEY_VALUE', 5),
+    ('NESTED_CARDS', 6)
 ])
 
 

--- a/assemblyline_v4_service/common/result.py
+++ b/assemblyline_v4_service/common/result.py
@@ -24,7 +24,7 @@ BODY_FORMAT = StringTable('BODY_FORMAT', [
     ('URL', 3),
     ('JSON', 4),
     ('KEY_VALUE', 5),
-    ('NESTED_CARDS', 6),
+    ('PROCESS_TREE', 6),
     ('TABLE', 7),
 ])
 


### PR DESCRIPTION
Added result section for nested cards that represent processes

test by following https://github.com/CybercentreCanada/assemblyline4_docs/blob/dev_setup_infra/docs/developer_manual/infrastructure/remote_development.md as well as pulling the other PRs for AL-248 from the other repos (base, ui)