### PR TITLE
Base methods and unit tests for dynamic service helper class

### DIFF
--- a/assemblyline_v4_service/common/dynamic_service_helper.py
+++ b/assemblyline_v4_service/common/dynamic_service_helper.py
@@ -1,6 +1,7 @@
 from typing import List
 from re import compile
 from assemblyline_v4_service.common.result import ResultSection
+from assemblyline_v4_service.common.request import ServiceRequest
 
 HOLLOWSHUNTER_EXE_REGEX = "hollowshunter\/hh_process_[0-9]{3,}_[a-zA-Z0-9]*\.*[a-zA-Z0-9]+\.exe$"
 HOLLOWSHUNTER_SHC_REGEX = "hollowshunter\/hh_process_[0-9]{3,}_[a-zA-Z0-9]*\.*[a-zA-Z0-9]+\.shc$"
@@ -149,7 +150,7 @@ class Ontology:
         raise NotImplementedError
 
     @staticmethod
-    def handle_artefacts(artefact_list: list) -> ResultSection:
+    def handle_artefacts(artefact_list: list, request: ServiceRequest) -> ResultSection:
         """
         Goes through each artefact in artefact_list, uploading them and adding result sections accordingly
 
@@ -165,12 +166,8 @@ class Ontology:
             Ontology._handle_artefact(artefact, artefacts_result_section)
 
             if artefact.to_be_extracted:
-                # Extract
-                # TODO: request.add_extracted(artefact.path, artefact.name, artefact.description)
-                pass
+                request.add_extracted(artefact.path, artefact.name, artefact.description)
             else:
-                # Supplementary
-                # TODO: request.add_supplementary(artefact.path, artefact.name, artefact.description)
-                pass
+                request.add_supplementary(artefact.path, artefact.name, artefact.description)
 
         return artefacts_result_section if artefacts_result_section.subsections else None

--- a/assemblyline_v4_service/common/dynamic_service_helper.py
+++ b/assemblyline_v4_service/common/dynamic_service_helper.py
@@ -1,0 +1,176 @@
+from typing import List
+from re import compile
+from assemblyline_v4_service.common.result import ResultSection
+
+HOLLOWSHUNTER_EXE_REGEX = "hollowshunter\/hh_process_[0-9]{3,}_[a-zA-Z0-9]*\.*[a-zA-Z0-9]+\.exe$"
+HOLLOWSHUNTER_SHC_REGEX = "hollowshunter\/hh_process_[0-9]{3,}_[a-zA-Z0-9]*\.*[a-zA-Z0-9]+\.shc$"
+HOLLOWSHUNTER_DLL_REGEX = "hollowshunter\/hh_process_[0-9]{3,}_[a-zA-Z0-9]*\.*[a-zA-Z0-9]+\.dll$"
+
+
+class Process:
+    def __init__(self, pid: int = None, ppid: int = None, image: str = None, command_line: str = None, timestamp: float = None):
+        self.pid = pid  # Same as ProcessID
+        self.ppid = ppid  # Same as ParentProcessID
+        self.image = image  # Same as Process Name
+        self.command_line = command_line
+        self.timestamp = timestamp  # Do we need this?  Also the equivalent of first_seen
+
+    def convert_process_to_dict(self):
+        return {
+            "pid": self.pid,
+            "ppid": self.ppid,
+            "image": self.image,
+            "command_line": self.command_line,
+            "timestamp": self.timestamp
+        }
+
+
+class Artefact:
+    def __init__(self, name: str = None, path: str = None, description: str = None, to_be_extracted: bool = None):
+        if any(item is None for item in [name, path, description, to_be_extracted]):
+            raise Exception("Missing positional arguments for Artefact validation")
+
+        self.name = name
+        self.path = path
+        self.description = description
+        self.to_be_extracted = to_be_extracted
+
+
+class Ontology:
+    def __init__(self, process_list: list = None):
+        if process_list is None:
+            self.process_list = []
+        else:
+            self.process_list = self._validate_process_list(process_list)
+
+    @staticmethod
+    def _validate_process_list(process_list) -> List[Process]:
+        valid_process_list = []
+        for process in process_list:
+            valid_process = Process(
+                pid=process["pid"],
+                ppid=process["ppid"],
+                image=process["image"],
+                command_line=process["command_line"],
+                timestamp=process["timestamp"],
+            )
+            valid_process_list.append(valid_process)
+        return valid_process_list
+
+    def _convert_processes_to_dict(self) -> dict:
+        processes_dict = {}
+        for process in self.process_list:
+            processes_dict[process.pid] = process.convert_process_to_dict()
+        return processes_dict
+
+    @staticmethod
+    def _convert_processes_dict_to_tree(processes_dict: dict = None) -> List[dict]:
+        root = {
+            "children": [],
+        }
+        sorted_processes = Ontology._sort_things_by_timestamp(list(processes_dict.values()))
+        procs_seen = []
+
+        for p in sorted_processes:
+            p["children"] = []
+            if p["ppid"] in procs_seen:
+                processes_dict[p["ppid"]]["children"].append(p)
+            else:
+                root["children"].append(p)
+
+            procs_seen.append(p["pid"])
+
+        return Ontology._sort_things_by_timestamp(root["children"])
+
+    @staticmethod
+    def _sort_things_by_timestamp(things_to_sort_by_timestamp: List[dict] = None) -> List[dict]:
+        timestamp = lambda x: x["timestamp"]
+        sorted_things = sorted(things_to_sort_by_timestamp, key=timestamp)
+        return sorted_things
+
+    @staticmethod
+    def _validate_artefacts(artefact_list: List[dict] = None) -> List[Artefact]:
+        if artefact_list is None:
+            artefact_list = []
+
+        validated_artefacts = []
+        for artefact in artefact_list:
+            validated_artefact = Artefact(
+                name=artefact["name"],
+                path=artefact["path"],
+                description=artefact["description"],
+                to_be_extracted=artefact["to_be_extracted"]
+            )
+            validated_artefacts.append(validated_artefact)
+        return validated_artefacts
+
+    @staticmethod
+    def _handle_artefact(artefact: Artefact = None, artefacts_result_section: ResultSection = None) -> ResultSection:
+        if artefact is None:
+            raise Exception("Artefact cannot be None")
+
+        # This is a dict who's key-value pairs follow the format {regex: result_section_title}
+        artefact_map = {
+            HOLLOWSHUNTER_EXE_REGEX: "HollowsHunter Injected Portable Executable",
+            HOLLOWSHUNTER_SHC_REGEX: "HollowsHunter Shellcode",
+            HOLLOWSHUNTER_DLL_REGEX: "HollowsHunter DLL",
+        }
+        artefact_result_section = None
+
+        for regex, title in artefact_map.items():
+            pattern = compile(regex)
+            if pattern.match(artefact.name):
+                artefact_result_section = ResultSection(title)
+                artefact_result_section.add_tag("dynamic.process.file_name", artefact.path)
+
+        if artefact_result_section is not None:
+            artefacts_result_section.add_subsection(artefact_result_section)
+
+    def get_process_tree(self) -> List[dict]:
+        processes_dict = self._convert_processes_to_dict()
+        process_tree = self._convert_processes_dict_to_tree(processes_dict)
+        return process_tree
+
+    @staticmethod
+    def get_events(process_list: List[dict] = None, network_calls: List[dict] = None) -> List[dict]:
+        if process_list is None:
+            process_list = []
+        if network_calls is None:
+            network_calls = []
+
+        events = process_list + network_calls
+        sorted_events = Ontology._sort_things_by_timestamp(events)
+        return sorted_events
+
+    def run_signatures(self) -> ResultSection:
+        """
+        Runs signatures against class attribute processes, and returns a ResultSection with the details
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def handle_artefacts(artefact_list: list) -> ResultSection:
+        """
+        Goes through each artefact in artefact_list, uploading them and adding result sections accordingly
+
+        Positional arguments:
+        artefact_list -- list of dictionaries that each represent an artefact
+        """
+
+        validated_artefacts = Ontology._validate_artefacts(artefact_list)
+
+        artefacts_result_section = ResultSection("Sandbox Artefacts")
+
+        for artefact in validated_artefacts:
+            Ontology._handle_artefact(artefact, artefacts_result_section)
+
+            if artefact.to_be_extracted:
+                # Extract
+                # TODO: request.add_extracted(artefact.path, artefact.name, artefact.description)
+                pass
+            else:
+                # Supplementary
+                # TODO: request.add_supplementary(artefact.path, artefact.name, artefact.description)
+                pass
+
+        return artefacts_result_section if artefacts_result_section.subsections else None

--- a/test/test_dynamic_service_helper.py
+++ b/test/test_dynamic_service_helper.py
@@ -1,0 +1,423 @@
+import pytest
+import os
+from pathlib import Path
+
+SERVICE_CONFIG_NAME = "service_manifest.yml"
+TEMP_SERVICE_CONFIG_PATH = os.path.join("/tmp", SERVICE_CONFIG_NAME)
+
+
+def check_process_equality(this, that):
+    if this.pid == that.pid and this.ppid == that.ppid and this.image == that.image \
+            and this.command_line == that.command_line and this.timestamp == that.timestamp:
+        return True
+    else:
+        return False
+
+
+def check_artefact_equality(this, that):
+    if this.name == that.name and this.path == that.path and this.description == that.description \
+            and this.to_be_extracted == that.to_be_extracted:
+        return True
+    else:
+        return False
+
+
+def check_section_equality(this, that) -> bool:
+    # Recursive method to check equality of result section and nested sections
+
+    # Heuristics also need their own equality checks
+    if this.heuristic and that.heuristic:
+        heuristic_equality = this.heuristic.definition.attack_id == that.heuristic.definition.attack_id and \
+                             this.heuristic.definition.classification == that.heuristic.definition.classification and \
+                             this.heuristic.definition.description == that.heuristic.definition.description and \
+                             this.heuristic.definition.filetype == that.heuristic.definition.filetype and \
+                             this.heuristic.definition.heur_id == that.heuristic.definition.heur_id and \
+                             this.heuristic.definition.id == that.heuristic.definition.id and \
+                             this.heuristic.definition.max_score == that.heuristic.definition.max_score and \
+                             this.heuristic.definition.name == that.heuristic.definition.name and \
+                             this.heuristic.definition.score == that.heuristic.definition.score and \
+                             this.heuristic.definition.signature_score_map == \
+                             that.heuristic.definition.signature_score_map
+
+        result_heuristic_equality = heuristic_equality and \
+                                    this.heuristic.attack_ids == that.heuristic.attack_ids and \
+                                    this.heuristic.frequency == that.heuristic.frequency and \
+                                    this.heuristic.heur_id == that.heuristic.heur_id and \
+                                    this.heuristic.score == that.heuristic.score and \
+                                    this.heuristic.score_map == that.heuristic.score_map and \
+                                    this.heuristic.signatures == that.heuristic.signatures
+
+    elif not this.heuristic and not that.heuristic:
+        result_heuristic_equality = True
+    else:
+        result_heuristic_equality = False
+
+    # Assuming we are given the "root section" at all times, it is safe to say that we don't need to confirm parent
+    current_section_equality = result_heuristic_equality and \
+                               this.body == that.body and \
+                               this.body_format == that.body_format and \
+                               this.classification == that.classification and \
+                               this.depth == that.depth and \
+                               len(this.subsections) == len(that.subsections) and \
+                               this.title_text == that.title_text
+
+    if not current_section_equality:
+        return False
+
+    for index, subsection in enumerate(this.subsections):
+        subsection_equality = check_section_equality(subsection, that.subsections[index])
+        if not subsection_equality:
+            return False
+
+    return True
+
+
+
+def setup_module():
+    if not os.path.exists(TEMP_SERVICE_CONFIG_PATH):
+        open_manifest = open(TEMP_SERVICE_CONFIG_PATH, "w")
+        open_manifest.write("name: Sample\nversion: sample\ndocker_config: \n  image: sample")
+
+
+def teardown_module():
+    if os.path.exists(TEMP_SERVICE_CONFIG_PATH):
+        os.remove(TEMP_SERVICE_CONFIG_PATH)
+
+
+class TestProcess:
+    @staticmethod
+    @pytest.mark.parametrize("pid, ppid, image, command_line, timestamp",
+        [
+            (None, None, None, None, None),
+            (1, 1, "blah", "blah", 1.0),
+        ]
+    )
+    def test_init(pid, ppid, image, command_line, timestamp):
+        from assemblyline_v4_service.common.dynamic_service_helper import Process
+        p = Process(pid=pid, ppid=ppid, image=image, command_line=command_line, timestamp=timestamp)
+        assert p.pid == pid
+        assert p.ppid == ppid
+        assert p.image == image
+        assert p.command_line == command_line
+        assert p.timestamp == timestamp
+
+    @staticmethod
+    @pytest.mark.parametrize("pid, ppid, image, command_line, timestamp, expected_result",
+        [
+            (None, None, None, None, None,
+                {"command_line": None, "image": None, "pid": None, "ppid": None, "timestamp": None}),
+            (1, 1, "blah", "blah", 1.0,
+                {"command_line": "blah", "image": "blah", "pid": 1, "ppid": 1, "timestamp": 1.0}),
+        ]
+    )
+    def test_convert_process_to_dict(pid, ppid, image, command_line, timestamp, expected_result):
+        from assemblyline_v4_service.common.dynamic_service_helper import Process
+        p = Process(pid=pid, ppid=ppid, image=image, command_line=command_line, timestamp=timestamp)
+        actual_result = p.convert_process_to_dict()
+        assert actual_result == expected_result
+
+
+class TestArtefact:
+    @staticmethod
+    @pytest.mark.parametrize("name, path, description, to_be_extracted",
+        [
+            (None, None, None, None),
+            ("blah", "blah", "blah", True),
+            ("blah", "blah", "blah", False),
+        ]
+    )
+    def test_init(name, path, description, to_be_extracted):
+        from assemblyline_v4_service.common.dynamic_service_helper import Artefact
+        if any(item is None for item in [name, path, description, to_be_extracted]):
+            with pytest.raises(Exception):
+                Artefact(name=name, path=path, description=description, to_be_extracted=to_be_extracted)
+            return
+        a = Artefact(name=name, path=path, description=description, to_be_extracted=to_be_extracted)
+        assert a.name == name
+        assert a.path == path
+        assert a.description == description
+        assert a.to_be_extracted == to_be_extracted
+
+
+class TestOntology:
+    @staticmethod
+    @pytest.mark.parametrize("process_list, expected_process_list", [(None, []), ([], [])])
+    def test_init(process_list, expected_process_list):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology
+        o = Ontology(process_list=process_list)
+        assert o.process_list == expected_process_list
+
+    @staticmethod
+    @pytest.mark.parametrize("process_list",
+        [
+            [],
+            [{"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": "blah"}],
+        ]
+    )
+    def test_validate_process_list(process_list):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology, Process
+        actual_validated_process_list = Ontology._validate_process_list(process_list)
+        for index, process in enumerate(process_list):
+            expected_process = Process(
+                pid=process["pid"],
+                ppid=process["ppid"],
+                image=process["image"],
+                command_line=process["command_line"],
+                timestamp=process["timestamp"],
+            )
+            assert check_process_equality(expected_process, actual_validated_process_list[index])
+
+    @staticmethod
+    @pytest.mark.parametrize("process_list, expected_result",
+        [
+            ([], {}),
+            (
+                [{"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": "blah"}],
+                {1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": "blah"}}
+            ),
+        ]
+    )
+    def test_convert_processes_to_dict(process_list, expected_result):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology
+        validated_process_list = Ontology(process_list)
+        actual_result = validated_process_list._convert_processes_to_dict()
+        assert actual_result == expected_result
+
+    @staticmethod
+    @pytest.mark.parametrize("processes_dict, expected_result",
+        [
+            # No processes
+            ({}, []),
+            # One process
+            (
+                    {1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1}},
+                    [{"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "children": []}]
+            ),
+            # One parent process and one child process
+            (
+                    {
+                        1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1},
+                        2: {"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1},
+                    },
+                    [
+                        {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1,
+                         "children":
+                             [{"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "children": []},]
+                        },
+                    ],
+            ),
+            # Two unrelated processes
+            (
+                    {
+                        1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1},
+                        2: {"pid": 2, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 1},
+                    },
+                    [
+                        {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "children": []},
+                        {"pid": 2, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 1, "children": []},
+                    ],
+            ),
+            # Three processes consisting of a parent-child relationship and a rando process
+            (
+                    {
+                        1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1},
+                        2: {"pid": 2, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 1},
+                        3: {"pid": 3, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 1},
+                    },
+                    [
+                        {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "children": []},
+                        {"pid": 2, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 1,
+                         "children":
+                             [{"pid": 3, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 1, "children": []},]
+                         },
+                    ],
+            ),
+            # Three processes consisting of a grandparent-parent-child relationship and one rando process
+            (
+                    {
+                        1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1},
+                        2: {"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 2},
+                        3: {"pid": 3, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 3},
+                        4: {"pid": 4, "ppid": 4, "image": "blah", "command_line": "blah", "timestamp": 2},
+                    },
+                    [
+                        {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1,
+                         "children":
+                            [{"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 2,
+                              "children":
+                                  [{"pid": 3, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 3,
+                                    "children": []}, ]}]
+                         },
+                        {"pid": 4, "ppid": 4, "image": "blah", "command_line": "blah", "timestamp": 2, "children": []}
+                    ],
+            ),
+            # Four processes consisting of a grandparent-parent-parent-child relationship
+            (
+                    {
+                        1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1},
+                        2: {"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 2},
+                        3: {"pid": 3, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 3},
+                        4: {"pid": 4, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 4},
+                    },
+                    [
+                        {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1,
+                         "children":
+                             [
+                                 {"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 2,
+                                  "children":
+                                      [{"pid": 4, "ppid": 2, "image": "blah", "command_line": "blah", "timestamp": 4, "children": []}]},
+                                 {"pid": 3, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 3, "children": []}
+                              ]
+                         },
+                    ],
+            ),
+        ]
+    )
+    def test_convert_processes_dict_to_tree(processes_dict, expected_result):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology
+        actual_result = Ontology._convert_processes_dict_to_tree(processes_dict)
+        assert expected_result == actual_result
+
+    @staticmethod
+    @pytest.mark.parametrize("things_to_sort_by_timestamp, expected_result",
+        [
+            ([], []),
+            (
+                    [{"timestamp": 1}],
+                    [{"timestamp": 1}]
+            ),
+            (
+                    [{"timestamp": 1}, {"timestamp": 2}],
+                    [{"timestamp": 1}, {"timestamp": 2}]
+            ),
+            (
+                    [{"timestamp": 1}, {"timestamp": 1}],
+                    [{"timestamp": 1}, {"timestamp": 1}]
+            ),
+            (
+                    [{"timestamp": 2}, {"timestamp": 1}],
+                    [{"timestamp": 1}, {"timestamp": 2}]
+            ),
+            (
+                    [{"timestamp": 3}, {"timestamp": 2}, {"timestamp": 1}],
+                    [{"timestamp": 1}, {"timestamp": 2}, {"timestamp": 3}]
+            ),
+        ]
+    )
+    def test_sort_things_by_timestamp(things_to_sort_by_timestamp, expected_result):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology
+        actual_result = Ontology._sort_things_by_timestamp(things_to_sort_by_timestamp)
+        assert actual_result == expected_result
+
+    @staticmethod
+    @pytest.mark.parametrize("artefact_list",
+        [
+            None,
+            [],
+            [{"name": "blah", "path": "blah", "description": "blah", "to_be_extracted": True}],
+        ]
+    )
+    def test_validate_artefacts(artefact_list):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology, Artefact
+        actual_validated_artefact_list = Ontology._validate_artefacts(artefact_list)
+        if artefact_list is None:
+            artefact_list = []
+        for index, artefact in enumerate(artefact_list):
+            expected_artefact = Artefact(
+                name=artefact["name"],
+                path=artefact["path"],
+                description=artefact["description"],
+                to_be_extracted=artefact["to_be_extracted"]
+            )
+            assert check_artefact_equality(expected_artefact, actual_validated_artefact_list[index])
+
+    @staticmethod
+    @pytest.mark.parametrize("artefact, expected_result_section_title",
+        [
+            (None, None),
+            ({"path": "blah", "name": "blah", "description": "blah", "to_be_extracted": True}, None),
+            ({"path": "blah", "name": "hollowshunter/hh_process_123_blah.exe", "description": "blah", "to_be_extracted": True}, "HollowsHunter Injected Portable Executable"),
+            ({"path": "blah", "name": "hollowshunter/hh_process_123_blah.shc", "description": "blah", "to_be_extracted": True}, "HollowsHunter Shellcode"),
+            ({"path": "blah", "name": "hollowshunter/hh_process_123_blah.dll", "description": "blah", "to_be_extracted": True}, "HollowsHunter DLL"),
+        ]
+    )
+    def test_handle_artefact(artefact, expected_result_section_title):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology, Artefact
+        from assemblyline_v4_service.common.result import ResultSection
+
+        if artefact is None:
+            with pytest.raises(Exception):
+                Ontology._handle_artefact(artefact, None)
+            return
+
+        expected_result_section = None
+        if expected_result_section_title is not None:
+            expected_result_section = ResultSection(expected_result_section_title)
+            expected_result_section.add_tag("dynamic.process.file_name", artefact["path"])
+
+        parent_result_section = ResultSection("blah")
+        a = Artefact(
+            name=artefact["name"],
+            path=artefact["path"],
+            description=artefact["description"],
+            to_be_extracted=artefact["to_be_extracted"]
+        )
+        Ontology._handle_artefact(a, parent_result_section)
+        if len(parent_result_section.subsections) > 0:
+            actual_result_section = parent_result_section.subsections[0]
+        else:
+            actual_result_section = None
+
+        if expected_result_section is None and actual_result_section is None:
+            assert True
+        else:
+            assert check_section_equality(actual_result_section, expected_result_section)
+
+    @staticmethod
+    @pytest.mark.parametrize("process_list, expected_result", [(None, []), ([], [])])
+    def test_get_process_tree(process_list, expected_result):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology
+        o = Ontology(process_list)
+        actual_result = o.get_process_tree()
+        assert actual_result == expected_result
+
+    @staticmethod
+    @pytest.mark.parametrize("processes, network_calls, expected_result",
+        [
+            (None, None, []),
+            ([], [], []),
+            ([{"pid": 1, "timestamp": 1}], [], [{"pid": 1, "timestamp": 1}]),
+            ([], [{"domain": "blah", "timestamp": 1}], [{"domain": "blah", "timestamp": 1}]),
+            ([{"pid": 1, "timestamp": 1}], [{"domain": "blah", "timestamp": 1}], [{"pid": 1, "timestamp": 1}, {"domain": "blah", "timestamp": 1}]),
+            ([{"pid": 1, "timestamp": 1}], [{"domain": "blah", "timestamp": 2}], [{"pid": 1, "timestamp": 1}, {"domain": "blah", "timestamp": 2}]),
+            ([{"pid": 1, "timestamp": 2}], [{"domain": "blah", "timestamp": 1}], [{"domain": "blah", "timestamp": 1}, {"pid": 1, "timestamp": 2}]),
+        ]
+    )
+    def test_get_events(processes, network_calls, expected_result):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology
+        actual_result = Ontology.get_events(processes, network_calls)
+        assert actual_result == expected_result
+
+    # TODO: implement this
+    # @staticmethod
+    # def test_run_signatures():
+    #     from assemblyline_v4_service.common.dynamic_service_helper import Ontology
+    #     o = Ontology()
+    #     actual_result = o.run_signatures()
+    #     assert actual_result is True
+
+    @staticmethod
+    @pytest.mark.parametrize("artefact_list, expected_result",
+        [
+            (None, None),
+            ([], None),
+            ([{"name": "blah", "path": "blah", "description": "blah", "to_be_extracted": True}], None),
+            ([{"name": "blah", "path": "blah", "description": "blah", "to_be_extracted": False}], None),
+        ]
+    )
+    def test_handle_artefacts(artefact_list, expected_result):
+        from assemblyline_v4_service.common.dynamic_service_helper import Ontology
+        o = Ontology()
+        actual_result = o.handle_artefacts(artefact_list)
+        assert actual_result == expected_result
+


### PR DESCRIPTION
The purpose of this PR is so that there is a class that dynamic services can import and use to do the following:

- A single place to handle sandbox artefacts
- A single place to handle converting process lists to process trees
- A single place to run generic signatures on process lists and trees


Closes https://cccs.atlassian.net/browse/AL-1050