### PR TITLE
Tweaking format of signatures in process tree

### DIFF
--- a/assemblyline_v4_service/common/dynamic_service_helper.py
+++ b/assemblyline_v4_service/common/dynamic_service_helper.py
@@ -257,15 +257,17 @@ class SandboxOntology(Events):
         process_event_dicts_with_signatures = {}
         copy_of_process_event_dicts = self.process_event_dicts.copy()
         for pid, process_event_dict in copy_of_process_event_dicts.items():
-            process_event_dict["signatures"] = []
+            process_event_dict["signatures"] = {}
             process_event_dicts_with_signatures[pid] = process_event_dict
 
         for signature_dict in signature_dicts:
             pid = signature_dict["pid"]
+            name = signature_dict["name"]
+            score = signature_dict["score"]
             if pid not in process_event_dicts_with_signatures:
                 raise Exception(f"{signature_dict} does not match up with a PID in {process_event_dicts_with_signatures.keys()}")
             else:
-                process_event_dicts_with_signatures[pid]["signatures"].append(signature_dict)
+                process_event_dicts_with_signatures[pid]["signatures"][name] = score
 
         return process_event_dicts_with_signatures
 

--- a/test/test_dynamic_service_helper.py
+++ b/test/test_dynamic_service_helper.py
@@ -465,8 +465,8 @@ class TestSandboxOntology:
         [
             (None, [], {}),
             ([], [], {}),
-            ([{"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah"}], [{"pid": 1, "name": "blah", "score": 1}], {1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah", "signatures": [{"pid": 1, "name": "blah", "score": 1}]}}),
-            ([{"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah"}], [{"pid": 1, "name": "blah", "score": 1}], {1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah", "signatures": [{"pid": 1, "name": "blah", "score": 1}]}}),
+            ([{"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah"}], [{"pid": 1, "name": "blah", "score": 1}], {1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah", "signatures": {"blah": 1}}}),
+            ([{"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah"}], [{"pid": 1, "name": "blah", "score": 1}], {1: {"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah", "signatures": {"blah": 1}}}),
         ]
     )
     def test_match_signatures_to_process_events(process_list, signatures, expected_result):
@@ -492,8 +492,8 @@ class TestSandboxOntology:
         [
             (None, [], []),
             ([], [], []),
-            ([{"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah"}], [{"pid": 1, "name": "blah", "score": 1}], [{"children": [], "pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah", "signatures": [{"pid": 1, "name": "blah", "score": 1}]}]),
-            ([{"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah"}], [{"pid": 1, "name": "blah", "score": 1}], [{"children": [], "pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah", "signatures": [{"pid": 1, "name": "blah", "score": 1}]}]),
+            ([{"pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah"}], [{"pid": 1, "name": "blah", "score": 1}], [{"children": [], "pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah", "signatures": {"blah": 1}}]),
+            ([{"pid": 2, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah"}], [{"pid": 1, "name": "blah", "score": 1}], [{"children": [], "pid": 1, "ppid": 1, "image": "blah", "command_line": "blah", "timestamp": 1, "guid": "blah", "signatures": {"blah": 1}}]),
         ]
     )
     def test_get_process_tree_with_signatures(process_list, signatures, expected_result):


### PR DESCRIPTION
Previous format would not have translated to being represented in the UI correctly.