### PR TITLE
Updating execute return type hint to match current services

### DIFF
--- a/assemblyline_v4_service/common/base.py
+++ b/assemblyline_v4_service/common/base.py
@@ -55,7 +55,7 @@ class ServiceBase:
     def _success(self) -> None:
         self._task.success()
 
-    def execute(self, request: ServiceRequest) -> Dict[str, Any]:
+    def execute(self, request: ServiceRequest) -> None:
         raise NotImplementedError("execute() function not implemented")
 
     def get_service_version(self) -> str:


### PR DESCRIPTION
I don't know of any use case for returning Dict[str, Any] from execute. If there is one it should be changed to Optional[Dict[str, Any]] instead, but if not None is the better return type to avoid confusion.