### PR TITLE
Bug fix in safelist tag query URL

### DIFF
--- a/assemblyline_v4_service/common/api.py
+++ b/assemblyline_v4_service/common/api.py
@@ -58,7 +58,7 @@ class ServiceAPI:
             if not isinstance(tag_list, list):
                 raise ValueError("Parameter tag_list should be a list of strings.")
 
-            url = f"{self.service_api_host}/api/v1/safelist/?{','.join(tag_list)}"
+            url = f"{self.service_api_host}/api/v1/safelist/?tags={','.join(tag_list)}"
         else:
             url = f"{self.service_api_host}/api/v1/safelist/"
 


### PR DESCRIPTION
According to https://github.com/CybercentreCanada/assemblyline-service-server/blob/2d8679888c14872baa1505b42afd6245d935b144/assemblyline_service_server/api/v1/safelist.py#L58
we need the `tags` param in the URL