### PR TITLE
use version env, not tag for pip

### DIFF
--- a/pipelines/azure-build.yaml
+++ b/pipelines/azure-build.yaml
@@ -132,7 +132,7 @@ stages:
         export VERSION=${TAG/stable}
         export VERSION=${VERSION/beta/b}
         export SERIES="`expr $TAG : '\([0-9]\+\.[0-9]\+\.\)'`${BUILD_TYPE}"
-        until sudo env "PATH=$PATH" python -m pip download "assemblyline-v4-service==$TAG" --pre --no-deps &> /dev/null; do sleep 2; done
+        until sudo env "PATH=$PATH" python -m pip download "assemblyline-v4-service==$VERSION" --pre --no-deps &> /dev/null; do sleep 2; done
 
         export IMAGE="cccs/assemblyline-v4-service-base"
         docker build --build-arg version=$VERSION --build-arg branch=$BUILD_TYPE -t $IMAGE:$TAG -t $IMAGE:$SERIES -t $IMAGE:BUILD_TYPE docker


### PR DESCRIPTION
difference between 4.0.0.stable0 vs 4.0.0.0 (which exists in pypi)