### PR TITLE
Depricate base64_search and mark pe_files_with_offsets as private

### DIFF
--- a/assemblyline_v4_service/common/extractor/base64.py
+++ b/assemblyline_v4_service/common/extractor/base64.py
@@ -4,6 +4,7 @@ Base 64 encoded text
 
 import binascii
 import re
+import warnings
 
 from typing import Dict, List, Tuple
 
@@ -25,6 +26,7 @@ def base64_search(text: bytes) -> Dict[bytes, bytes]:
         A dictionary with the original base64 encoded sections as keys
         and the corresponding decoded data as values.
     """
+    warnings.warn("base64_search is depricated, use find_base64 instead", DeprecationWarning)
     b64_matches = {}
     for b64_match in re.findall(BASE64_RE, text):
         if b64_match in b64_matches:

--- a/assemblyline_v4_service/common/extractor/pe_file.py
+++ b/assemblyline_v4_service/common/extractor/pe_file.py
@@ -8,7 +8,7 @@ EXEDOS_RE = rb'(?s)This program cannot be run in DOS mode'
 EXEHEADER_RE = rb'(?s)MZ.{32,1024}PE\000\000'
 
 
-def find_pe_files_with_offset(data: bytes) -> List[Tuple[bytes, int, int]]:
+def _find_pe_files_with_offset(data: bytes) -> List[Tuple[bytes, int, int]]:
     """
     Searches for any PE files within data
 
@@ -48,4 +48,4 @@ def find_pe_files(data: bytes) -> List[bytes]:
     Returns:
         A list of found PE files
     """
-    return [pe[0] for pe in find_pe_files_with_offset(data)]
+    return [pe[0] for pe in _find_pe_files_with_offset(data)]


### PR DESCRIPTION
base64_search will not have updated false positive detection and
so shouldn't be used. There is no current use case for the offsets of
find_pe_files_with_offsets so marking it as private minimizes the
public surface of the library that is commited to not changing.