### PR TITLE
Switch to using the regex library over the builtin re (Dev)

### DIFF
--- a/assemblyline_v4_service/common/balbuzard/balbuzard.py
+++ b/assemblyline_v4_service/common/balbuzard/balbuzard.py
@@ -121,7 +121,7 @@ import glob
 import optparse
 import os
 import os.path
-import re
+import regex as re
 import string
 import sys
 import time

--- a/assemblyline_v4_service/common/balbuzard/bbcrack.py
+++ b/assemblyline_v4_service/common/balbuzard/bbcrack.py
@@ -699,7 +699,7 @@ def xor_simple(a, b):
 
 def deobfuscate_simple(d, r, m):
     "Take mask and will create a key to unmask suspected data, then check if the xor'd data matches a regex pattern"
-    import re
+    import regex as re
     max_mask = m.lower()
     for i in range(1, len(max_mask)+1):
         t_mask = max_mask[:i]

--- a/assemblyline_v4_service/common/balbuzard/patterns.py
+++ b/assemblyline_v4_service/common/balbuzard/patterns.py
@@ -33,7 +33,7 @@ For more info and updates: http://www.decalage.info/balbuzard
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import re
+import regex as re
 from os import path
 from xml.etree import ElementTree
 
@@ -204,7 +204,7 @@ class PatternMatch(object):
                   rb'OSX|PAF|PDF|PNG|PPT|PPTX|PS1|RAR|RTF|SCR|SWF|SYS|[T]?BZ[2]?|TXT|TMP|VBE|VBS|WSF|WSH|XLS' \
                   rb'|XLSX|ZIP)\b'
     PAT_FILEPDB = rb'(?i)\b[-_A-Z0-9.\\]{0,200}\w\.PDB\b'
-    PAT_EMAIL = rb'(?i)\b[A-Z0-9._%+-]{3,}@(?:[A-Z0-9-]+\.)+(?:XN--[A-Z0-9]{4,18}|[A-Z]{2,12})\b'
+    PAT_EMAIL = rb'(?i)\b[A-Z0-9._%+-]{3,200}@(?:[A-Z0-9-]+\.)+(?:XN--[A-Z0-9]{4,18}|[A-Z]{2,12})\b'
     PAT_IP = rb'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b'
     PAT_REGIS = rb'(?i)\b[- _A-Z0-9.\\]{0,25}' \
                 rb'(?:controlset001|controlset002|currentcontrolset|currentversion|HKCC|HKCR|HKCU|HKDD|' \

--- a/assemblyline_v4_service/common/extractor/base64.py
+++ b/assemblyline_v4_service/common/extractor/base64.py
@@ -3,7 +3,7 @@ Base 64 encoded text
 """
 
 import binascii
-import re
+import regex as re
 import warnings
 
 from typing import Dict, List, Tuple

--- a/assemblyline_v4_service/common/extractor/pe_file.py
+++ b/assemblyline_v4_service/common/extractor/pe_file.py
@@ -1,4 +1,4 @@
-import re
+import regex as re
 
 from typing import List, Tuple
 

--- a/assemblyline_v4_service/common/tag_reducer.py
+++ b/assemblyline_v4_service/common/tag_reducer.py
@@ -1,4 +1,4 @@
-import re
+import regex as re
 import os.path
 
 from copy import deepcopy

--- a/assemblyline_v4_service/updater/helper.py
+++ b/assemblyline_v4_service/updater/helper.py
@@ -1,6 +1,6 @@
 import certifi
 import os
-import re
+import regex as re
 import requests
 import shutil
 import tempfile

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'pefile',
         'pillow',
         'python-Levenshtein',
+        'regex',
     ],
     extra_requires={
         'updater': [

--- a/test/test_tag_reducer.py
+++ b/test/test_tag_reducer.py
@@ -6,7 +6,7 @@ class TestTagReducer:
     def test_constants():
         from assemblyline_v4_service.common.tag_reducer import NUMBER_REGEX, ALPHA_REGEX, ALPHANUM_REGEX, \
             BASE64_REGEX, DO_NOT_REDUCE
-        from re import compile
+        from regex import compile
         assert NUMBER_REGEX == compile("[0-9]*")
         assert ALPHA_REGEX == compile("[a-zA-Z]*")
         assert ALPHANUM_REGEX == compile("[a-zA-Z0-9]*")


### PR DESCRIPTION
python's built in re library stalls on some common regexes on
specific data. Regex is a drop in replacement with fewer cases
that cause unusable performance.