### PR TITLE
Fixed bug with Azure DevOps unable to pull Yara rules [dev]

### DIFF
--- a/assemblyline_v4_service/updater/helper.py
+++ b/assemblyline_v4_service/updater/helper.py
@@ -209,7 +209,13 @@ def git_clone_repo(source: Dict[str, Any], previous_update: int = None, default_
             git_ssh_cmd = f"ssh -oStrictHostKeyChecking=no -i {git_ssh_identity_file.name}"
             git_env['GIT_SSH_COMMAND'] = git_ssh_cmd
 
-        repo = Repo.clone_from(url, clone_dir, env=git_env, config=git_config, branch=branch)
+        # As checking for .git at the end of the URI is not reliable
+        # we will use the exception to determine if its a git repo or direct download.
+        try:
+            repo = Repo.clone_from(url, clone_dir, env=git_env, config=git_config, branch=branch)
+        except Exception as ex:
+            logger.warning(f"Repo clone failed with: {str(ex)}")
+            return None # !!!Warning!!! Caller checks this to determine if we should try a direct download.
 
         # Check repo last commit
         if previous_update:

--- a/assemblyline_v4_service/updater/updater.py
+++ b/assemblyline_v4_service/updater/updater.py
@@ -380,8 +380,12 @@ class ServiceUpdater(ThreadedCoreBase):
                         self.push_status("UPDATING", "Pulling..")
 
                         # Pull sources from external locations (method depends on the URL)
-                        files = git_clone_repo(source, old_update_time, self.default_pattern, self.log, update_dir) \
-                            if uri.endswith('.git') else url_download(source, old_update_time, self.log, update_dir)
+                        files = git_clone_repo(source, old_update_time, self.default_pattern, self.log, update_dir)
+
+                        # As not all services end with .git, we rely on the exception thrown by git_clone which sets (files is None)
+                        # to determine if its a valid git repo or not.
+                        if (files is None) and (not uri.endswith('.git')):
+                            url_download(source, old_update_time, self.log, update_dir)
 
                         # Add to collection of sources for caching purposes
                         self.log.info(f"Found new {self.updater_type} rule files to process for {source_name}!")


### PR DESCRIPTION
ADO does not end its repos with ".git" which causes a failure when trying to pull Yara rules from ADO.