### PR TITLE
Check if pytest is in the stacktrace to determine DEV_MODE

### DIFF
--- a/assemblyline_v4_service/common/api.py
+++ b/assemblyline_v4_service/common/api.py
@@ -10,10 +10,12 @@ DEFAULT_AUTH_KEY = "ThisIsARandomAuthKey...ChangeMe!"
 DEVELOPMENT_MODE = False
 
 with StringIO() as stack_trace:
-    # Check if run_service_once is in the stack trace to determine if we're running the service in a development mode
+    # Check if run_service_once or pytest is in the stack trace to determine if we're running the service in a development mode
     traceback.print_stack(file=stack_trace)
     stack_trace.seek(0)
-    if 'run_service_once' in stack_trace.read():
+    read_stack_trace = stack_trace.read()
+
+    if 'run_service_once' in read_stack_trace or 'pytest' in read_stack_trace:
         DEVELOPMENT_MODE = True
 
 


### PR DESCRIPTION
For services that use `self.get_api_interface()`, this call will hang if they are run using `pytest`, which is different than `run_service_once`