### PR TITLE
Ability to pass the filename via params.json when testing samples

### DIFF
--- a/assemblyline_v4_service/testing/helper.py
+++ b/assemblyline_v4_service/testing/helper.py
@@ -87,6 +87,7 @@ class TestHelper:
         temp_submission_data = params.get('temp_submission_data', {})
         submission_params = params.get('submission_params', {})
         tags = params.get('tags', [])
+        filename = params.get('filename', os.path.basename(file_path))
 
         return ServiceTask(
             {
@@ -97,7 +98,7 @@ class TestHelper:
                 "service_config": {param.name: submission_params.get(param.name, param.default)
                                    for param in self.submission_params},
                 "fileinfo": {k: v for k, v in self.identify.fileinfo(file_path).items() if k in fileinfo_keys},
-                "filename": os.path.basename(file_path),
+                "filename": filename,
                 "min_classification": "TLP:W",
                 "max_files": 501,
                 "ttl": 3600,


### PR DESCRIPTION
Allows the testing of this ticket https://cccs.atlassian.net/browse/AL-2323