### PR TITLE
Inventory check

### DIFF
--- a/assemblyline_v4_service/updater/updater.py
+++ b/assemblyline_v4_service/updater/updater.py
@@ -304,11 +304,17 @@ class ServiceUpdater(ThreadedCoreBase):
             return check_passed
         for _, dirs, files in os.walk(self._update_dir):
             # Walk through update directory (account for sources being nested)
-            for i in dirs + files:
-                # We have at least one source we can pass to the service for now
-                if i in missing_sources:
-                    missing_sources.remove(i)
-                    check_passed = True
+            for path in dirs + files:
+                remove_source = None
+                for source in missing_sources:
+                    if source in path:
+                        # We have at least one source we can pass to the service for now
+                        remove_source = source
+                        check_passed = True
+                        break
+                if remove_source:
+                    missing_sources.remove(source)
+
             if not missing_sources:
                 break
 

--- a/assemblyline_v4_service/updater/updater.py
+++ b/assemblyline_v4_service/updater/updater.py
@@ -290,7 +290,6 @@ class ServiceUpdater(ThreadedCoreBase):
         if self._service.update_config.wait_for_update:
             new_service_stage = ServiceStage.Running if self._inventory_check() else ServiceStage.Update
 
-        self._service_stage_hash.set(SERVICE_NAME, new_service_stage)
         if old_service_stage != new_service_stage:
             # There has been a change in service stages, alert Scaler
             self.log.info(f"Moving service from stage: {old_service_stage} to {new_service_stage}")


### PR DESCRIPTION
Fix for: https://github.com/CybercentreCanada/assemblyline/issues/55, https://github.com/CybercentreCanada/assemblyline/issues/24

Instructs updaters to take inventory of what they have before declaring a service is ready to be scaled. If not ready, instructs scaler to scale down service instances until deemed ready.