### PR TITLE
Kv sections

### DIFF
--- a/assemblyline_v4_service/common/result.py
+++ b/assemblyline_v4_service/common/result.py
@@ -214,7 +214,7 @@ class SectionBody:
         return self._format
 
     @property
-    def body(self):
+    def body(self) -> str | None:
         if not self._data:
             return None
         elif not isinstance(self._data, str):
@@ -282,6 +282,7 @@ class GraphSectionBody(SectionBody):
 
 class KVSectionBody(SectionBody):
     def __init__(self, **kwargs: KV_VALUE_TYPE) -> None:
+        self._data: dict[str, KV_VALUE_TYPE]
         super().__init__(BODY_FORMAT.KEY_VALUE, body=kwargs)
 
     def set_item(self, key: str, value: KV_VALUE_TYPE) -> None:
@@ -293,6 +294,7 @@ class KVSectionBody(SectionBody):
 
 class OrderedKVSectionBody(SectionBody):
     def __init__(self, **kwargs: KV_VALUE_TYPE) -> None:
+        self._data: list[tuple[str, KV_VALUE_TYPE]]
         super().__init__(BODY_FORMAT.ORDERED_KEY_VALUE, body=[(str(key), value) for key, value in kwargs.items()])
 
     def add_item(self, key: str, value: KV_VALUE_TYPE) -> None:

--- a/assemblyline_v4_service/common/result.py
+++ b/assemblyline_v4_service/common/result.py
@@ -655,6 +655,7 @@ class ResultMemoryDumpSection(ResultSection):
 
 class ResultGraphSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List],  **kwargs):
+        self.section_body: GraphSectionBody
         super().__init__(title_text, GraphSectionBody(), **kwargs)
 
     def set_colormap(self, cmap_min: int, cmap_max: int, values: List[int]) -> None:
@@ -663,6 +664,7 @@ class ResultGraphSection(TypeSpecificResultSection):
 
 class ResultURLSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], **kwargs):
+        self.section_body: URLSectionBody
         super().__init__(title_text, URLSectionBody(), **kwargs)
 
     def add_url(self, url: str, name: Optional[str] = None) -> None:
@@ -671,6 +673,7 @@ class ResultURLSection(TypeSpecificResultSection):
 
 class ResultKeyValueSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], body: dict[str, KV_VALUE_TYPE] | None = None, **kwargs):
+        self.section_body: KVSectionBody
         if not body:
             body = {}
         super().__init__(title_text, KVSectionBody(**body), **kwargs)
@@ -684,6 +687,7 @@ class ResultKeyValueSection(TypeSpecificResultSection):
 
 class ResultOrderedKeyValueSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], body: dict[str, KV_VALUE_TYPE] | None = None, **kwargs):
+        self.section_body: OrderedKVSectionBody
         if not body:
             body = {}
         super().__init__(title_text, OrderedKVSectionBody(**body), **kwargs)
@@ -694,6 +698,7 @@ class ResultOrderedKeyValueSection(TypeSpecificResultSection):
 
 class ResultJSONSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], **kwargs):
+        self.section_body: JSONSectionBody
         super().__init__(title_text, JSONSectionBody(), **kwargs)
 
     def set_json(self, json_body: dict) -> None:
@@ -705,6 +710,7 @@ class ResultJSONSection(TypeSpecificResultSection):
 
 class ResultProcessTreeSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], **kwargs):
+        self.section_body: ProcessTreeSectionBody
         super().__init__(title_text, ProcessTreeSectionBody(), **kwargs)
 
     def add_process(self, process: ProcessItem) -> None:
@@ -713,6 +719,7 @@ class ResultProcessTreeSection(TypeSpecificResultSection):
 
 class ResultTableSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], **kwargs):
+        self.section_body: TableSectionBody
         super().__init__(title_text, TableSectionBody(), **kwargs)
 
     def add_row(self, row: TableRow) -> None:
@@ -740,6 +747,7 @@ class ResultImageSection(TypeSpecificResultSection):
 
 class ResultTimelineSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], **kwargs):
+        self.section_body: TimelineSectionBody
         super().__init__(title_text,  TimelineSectionBody(), **kwargs)
 
     def add_node(self, title: str, content: str, opposite_content: str, icon: str = None, signatures: List[str] = [],
@@ -750,6 +758,7 @@ class ResultTimelineSection(TypeSpecificResultSection):
 
 class ResultMultiSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], **kwargs):
+        self.section_body: MultiSectionBody
         super().__init__(title_text,  MultiSectionBody(), **kwargs)
 
     def add_section_part(self, section_part: SectionBody) -> bool:

--- a/assemblyline_v4_service/common/result.py
+++ b/assemblyline_v4_service/common/result.py
@@ -674,9 +674,7 @@ class ResultURLSection(TypeSpecificResultSection):
 class ResultKeyValueSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], body: dict[str, KV_VALUE_TYPE] | None = None, **kwargs):
         self.section_body: KVSectionBody
-        if not body:
-            body = {}
-        super().__init__(title_text, KVSectionBody(**body), **kwargs)
+        super().__init__(title_text, KVSectionBody(**(body if body else {})), **kwargs)
 
     def set_item(self, key: str, value: Union[str, bool, int]) -> None:
         self.section_body.set_item(key, value)
@@ -688,9 +686,7 @@ class ResultKeyValueSection(TypeSpecificResultSection):
 class ResultOrderedKeyValueSection(TypeSpecificResultSection):
     def __init__(self, title_text: Union[str, List], body: dict[str, KV_VALUE_TYPE] | None = None, **kwargs):
         self.section_body: OrderedKVSectionBody
-        if not body:
-            body = {}
-        super().__init__(title_text, OrderedKVSectionBody(**body), **kwargs)
+        super().__init__(title_text, OrderedKVSectionBody(**(body if body else {})), **kwargs)
 
     def add_item(self, key: str, value: Union[str, bool, int]) -> None:
         self.section_body.add_item(key, value)


### PR DESCRIPTION
- Allow OrderedKVSectionBody to be constructed from an existing dictionary.
- Add optional body parameter to ResultKeyValueSection and ResultOrderedKeyValueSection to pass a dictionary to their respective body types.
- Factor out the type used for values in KVSectionBody and OrderedKVSectionBody into a type variable.
- Type hint section_body for TypeSpecificResultSections.
- improve type hints generally.