### PR TITLE
Only get latest commit without complete Git history

### DIFF
--- a/assemblyline_v4_service/updater/helper.py
+++ b/assemblyline_v4_service/updater/helper.py
@@ -224,7 +224,7 @@ def git_clone_repo(source: Dict[str, Any], previous_update: int = None, logger=N
             # As checking for .git at the end of the URI is not reliable
             # we will use the exception to determine if its a git repo or direct download.
             repo = Repo.clone_from(url, clone_dir, env=git_env, branch=branch,
-                                   allow_unsafe_protocols=GIT_ALLOW_UNSAFE_PROTOCOLS)
+                                   allow_unsafe_protocols=GIT_ALLOW_UNSAFE_PROTOCOLS, depth=1)
 
             # Check repo last commit
             if previous_update:


### PR DESCRIPTION
The assumption, based on our experience, is that the updater isn't concerned with the full history of the repository so it makes little sense to clone with all the nitty-gritty details (especially if there is so many of those)