### PR TITLE
Close open handlers for timekeeper/signature archives

### DIFF
--- a/assemblyline_v4_service/updater/updater.py
+++ b/assemblyline_v4_service/updater/updater.py
@@ -332,7 +332,11 @@ class ServiceUpdater(ThreadedCoreBase):
             self.log.info(f"Connecting to Assemblyline API: {UI_SERVER}")
             al_client = get_client(UI_SERVER, apikey=(username, api_key), verify=self.verify, datastore=self.datastore)
 
-            _, time_keeper = tempfile.mkstemp(prefix="time_keeper_", dir=UPDATER_DIR)
+            # Create a temporary file for the time keeper
+            time_keeper = tempfile.NamedTemporaryFile(prefix="time_keeper_", dir=UPDATER_DIR, delete=False)
+            time_keeper.close()
+            time_keeper = time_keeper.name
+
             if self._service.update_config.generates_signatures:
                 output_directory = tempfile.mkdtemp(prefix="update_dir_", dir=UPDATER_DIR)
 
@@ -573,7 +577,10 @@ class ServiceUpdater(ThreadedCoreBase):
 
         try:
             # Tar update directory
-            _, new_tar = tempfile.mkstemp(prefix="signatures_", dir=UPDATER_DIR, suffix='.tar.bz2')
+            new_tar = tempfile.NamedTemporaryFile(prefix="signatures_", dir=UPDATER_DIR, suffix='.tar.bz2',
+                                                  delete=False)
+            new_tar.close()
+            new_tar = new_tar.name
             tar_handle = tarfile.open(new_tar, 'w:bz2')
             tar_handle.add(new_directory, '/')
             tar_handle.close()


### PR DESCRIPTION
Related to: https://github.com/CybercentreCanada/assemblyline/issues/137

After running this test in our production systems where the updater should have stabilized (ie. ready to serve clients), it yields a single process with 2 open files, which it shouldn't at this stage if it's just idle:
```python
import psutil
for proc in psutil.process_iter():
  print(proc.open_files())
```
Output:
```
[popenfile(path='/mnt/updates/time_keeper_55c5ayx2', fd=19, position=0, mode='r+', flags=688130), popenfile(path='/mnt/updates/signatures_r1tfxo1u.tar.bz2', fd=21, position=0, mode='r+', flags=688130)]
...
[]
```

After rebuilding a service updater with the patch, it currently shows no open files by any of the processes. This should help resolve any issues with unlinking files that are still open, causing disk space to not be freed as mentioned in the issue. 