### PR TITLE
Hashlist syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,7 @@ To test an Assemblyline service in standalone mode, the [run_service_once.py](ht
 2. From a terminal, run the `run_service_once` script, where `<service path>` is the path to the service module and `<file path>` is the path of the file to be processed
 
    ```shell
-   python3.9 -m assemblyline_v4_service.dev.run_service_once <service path> <file path>
-   ```
-   python3.7 -m assemblyline_v4_service.dev.run_service_once <service path> <file path>
+   python3.11 -m assemblyline_v4_service.dev.run_service_once <service path> <file path>
    ```
 
 
@@ -225,10 +223,7 @@ To test an Assemblyline service in standalone mode, the [run_service_once.py](ht
 2. From a terminal, run the `run_service_once` script
 
    ```shell
-   python3.9 -m assemblyline_v4_service.dev.run_service_once assemblyline_result_sample_service.result_sample.ResultSample /home/ubuntu/testfile.doc
+   python3.11 -m assemblyline_v4_service.dev.run_service_once assemblyline_result_sample_service.result_sample.ResultSample /home/ubuntu/testfile.doc
    ```
-   python3.7 -m assemblyline_v4_service.dev.run_service_once assemblyline_result_sample_service.result_sample.ResultSample /home/ubuntu/testfile.doc
-   ```
-
 
 3. The `results.json` and any extracted/supplementary files will be outputted to `/home/ubuntu/testfile_resultsample`

--- a/assemblyline_v4_service/updater/client.py
+++ b/assemblyline_v4_service/updater/client.py
@@ -1,5 +1,6 @@
 import os
 
+from assemblyline.datastore.collection import ESCollection
 from assemblyline.odm.models.badlist import Badlist as BadlistModel
 from assemblyline.odm.models.safelist import Safelist as SafelistModel
 from assemblyline.odm.models.signature import Signature as SignatureModel
@@ -18,85 +19,7 @@ class SyncableBadlistClient(BadlistClient):
         self.sync = False
 
     def add_update_many(self, data: List[Union[dict, BadlistModel]]) -> Dict[str, Any]:
-        # This version of the API allows to sync badlist items with the system by making direct changes to the datastore
-        # Items that no longer exist at the source will be removed from `sources` to maintain active synchronicity
-        # amongst multiple sources.
-        # If there are no more sources actively blocking the item, then the item will be DISABLED but users can always
-        # re-deploy item if desired
-
-        current_ids = set()
-        source = None
-
-        # Iterate over the list of signatures given
-        for i, d in enumerate(data):
-            if isinstance(d, BadlistModel):
-                d = d.as_primitives()
-
-            if not source:
-                # Set the source name
-                source = data["sources"][0]["name"]
-
-            if self.sync:
-                # Compute the expected badlist ID and add it to the list
-                current_ids.add(self._preprocess_object(d))
-
-            # Update with JSON-friendly version of data to be sent to API
-            data[i] = d
-
-        if self.sync:
-            # Get the list of items that currently existing in the system for the source
-            existing_ids = set(
-                [
-                    i["id"]
-                    for i in self.datastore.badlist.stream_search(
-                        f"sources.name:{source}", fl="id", as_obj=False
-                    )
-                ]
-            )
-
-            # Find the IDs that don't exist at this source anymore and remove the source from the source list
-            for missing_id in existing_ids - current_ids:
-                missing_item: BadlistModel = self.datastore.badlist.get(missing_id)
-                original_sources = missing_item.sources
-                missing_item.sources = [
-                    s
-                    for s in missing_item.sources
-                    if not (s.type == "external" and s.name == source)
-                ]
-
-                # If there are no more sources to back this item, then disable it but leave at least one source
-                if not missing_item.sources:
-                    missing_item.enabled = False
-                    missing_item.sources = original_sources[:1]
-
-                # Update the last updated time
-                missing_item.updated = "NOW"
-
-                # Update missing item with latest changes
-                self.datastore.badlist.save(missing_id, missing_item)
-
-        # Proceed with adding/updating items
-        if len(data) < SIGNATURE_UPDATE_BATCH:
-            # Update all of them in a single batch
-            return super().add_update_many(data)
-        else:
-            response = {"success": 0, "errors": []}
-
-            def update_response(r: Dict[str, Any]):
-                # Response has to be in the same format, but show the accumulation of batches
-                response["success"]: int = response["success"] + r["success"]
-                response["errors"]: List[str] = response["errors"] + r["errors"]
-
-            # Split up data into batches to avoid server timeouts handling requests
-            batch_num = 0
-            start = batch_num * SIGNATURE_UPDATE_BATCH
-            while start < len(data):
-                end = (batch_num + 1) * SIGNATURE_UPDATE_BATCH
-                update_response(super().add_update_many(data[start:end]))
-                batch_num += 1
-                start = batch_num * SIGNATURE_UPDATE_BATCH
-
-            return response
+        return hashlist_add_update_many(self, self.datastore.badlist, data)
 
 
 class SyncableSafelistClient(SafelistClient):
@@ -105,85 +28,93 @@ class SyncableSafelistClient(SafelistClient):
         self.sync = False
 
     def add_update_many(self, data: List[Union[dict, SafelistModel]]) -> Dict[str, Any]:
-        # This version of the API allows to sync safelist items with the system by making direct changes to the datastore
-        # Items that no longer exist at the source will be removed from `sources` to maintain active synchronicity
-        # amongst multiple sources.
-        # If there are no more sources actively safelisting the item, then the item will be DISABLED but users can always
-        # re-deploy item if desired
+        return hashlist_add_update_many(self, self.datastore.safelist, data)
 
-        current_ids = set()
-        source = None
 
-        # Iterate over the list of signatures given
-        for i, d in enumerate(data):
-            if isinstance(d, SafelistModel):
-                d = d.as_primitives()
+def hashlist_add_update_many(client: Union[SyncableBadlistClient, SyncableSafelistClient],
+                             collection: ESCollection,
+                             data: List[Union[dict, BadlistModel, SafelistModel]]):
+    # This generic function allows to sync hashlist items with the system by making direct changes to the datastore
+    # Items that no longer exist at the source will be removed from `sources` to maintain active synchronicity
+    # amongst multiple sources.
+    # If there are no more sources actively blocking the item, then the item will be DISABLED but users can always
+    # re-deploy item if desired
 
-            if not source:
-                # Set the source name
-                source = data["sources"][0]["name"]
+    if not data:
+        return {"success": 0, "errors": False}
 
-            if self.sync:
-                # Compute the expected safelist ID and add it to the list
-                current_ids.add(self._preprocess_object(d))
+    current_ids = set()
+    source = None
 
-            # Update with JSON-friendly version of data to be sent to API
-            data[i] = d
+    # Iterate over the list of signatures given
+    for i, d in enumerate(data):
+        if isinstance(d, collection.model_class):
+            d = d.as_primitives()
 
-        if self.sync:
-            # Get the list of items that currently existing in the system for the source
-            existing_ids = set(
-                [
-                    i["id"]
-                    for i in self.datastore.safelist.stream_search(
-                        f"sources.name:{source}", fl="id", as_obj=False
-                    )
-                ]
-            )
+        if not source:
+            # Set the source name
+            source = d["sources"][0]["name"]
 
-            # Find the IDs that don't exist at this source anymore and remove the source from the source list
-            for missing_id in existing_ids - current_ids:
-                missing_item: SafelistModel = self.datastore.safelist.get(missing_id)
-                original_sources = missing_item.sources
-                missing_item.sources = [
-                    s
-                    for s in missing_item.sources
-                    if not (s.type == "external" and s.name == source)
-                ]
+        if client.sync:
+            # Compute the expected ID and add it to the list
+            current_ids.add(client._preprocess_object(d))
+        # Update with JSON-friendly version of data to be sent to API
+        data[i] = d
 
-                # If there are no more sources to back this item, then disable it but leave at least one source
-                if not missing_item.sources:
-                    missing_item.enabled = False
-                    missing_item.sources = original_sources[:1]
+    if client.sync:
+        # Get the list of items that currently existing in the system for the source
+        existing_ids = set(
+            [
+                i["id"]
+                for i in collection.stream_search(
+                    f"sources.name:{source}", fl="id", as_obj=False
+                )
+            ]
+        )
 
-                # Update the last updated time
-                missing_item.updated = "NOW"
+        # Find the IDs that don't exist at this source anymore and remove the source from the source list
+        for missing_id in existing_ids - current_ids:
+            missing_item = collection.get(missing_id)
+            original_sources = missing_item.sources
+            missing_item.sources = [
+                s
+                for s in missing_item.sources
+                if not (s.type == "external" and s.name == source)
+            ]
 
-                # Update missing item with latest changes
-                self.datastore.safelist.save(missing_id, missing_item)
+            # If there are no more sources to back this item, then disable it but leave at least one source
+            if not missing_item.sources:
+                missing_item.enabled = False
+                missing_item.sources = original_sources[:1]
 
-        # Proceed with adding/updating items
-        if len(data) < SIGNATURE_UPDATE_BATCH:
-            # Update all of them in a single batch
-            return super().add_update_many(data)
-        else:
-            response = {"success": 0, "errors": []}
+            # Update the last updated time
+            missing_item.updated = "NOW"
 
-            def update_response(r: Dict[str, Any]):
-                # Response has to be in the same format, but show the accumulation of batches
-                response["success"]: int = response["success"] + r["success"]
-                response["errors"]: List[str] = response["errors"] + r["errors"]
+            # Update missing item with latest changes
+            collection.save(missing_id, missing_item)
 
-            # Split up data into batches to avoid server timeouts handling requests
-            batch_num = 0
+    # Proceed with adding/updating items
+    if len(data) < SIGNATURE_UPDATE_BATCH:
+        # Update all of them in a single batch
+        return super(client.__class__, client).add_update_many(data)
+    else:
+        response = {"success": 0, "errors": False}
+
+        def update_response(r: Dict[str, Any]):
+            # Response has to be in the same format, but show the accumulation of batches
+            response["success"]: int = response["success"] + r["success"]
+            response["errors"]: bool = response["errors"] and r["errors"]
+
+        # Split up data into batches to avoid server timeouts handling requests
+        batch_num = 0
+        start = batch_num * SIGNATURE_UPDATE_BATCH
+        while start < len(data):
+            end = (batch_num + 1) * SIGNATURE_UPDATE_BATCH
+            update_response(super(client.__class__, client).add_update_many(data[start:end]))
+            batch_num += 1
             start = batch_num * SIGNATURE_UPDATE_BATCH
-            while start < len(data):
-                end = (batch_num + 1) * SIGNATURE_UPDATE_BATCH
-                update_response(super().add_update_many(data[start:end]))
-                batch_num += 1
-                start = batch_num * SIGNATURE_UPDATE_BATCH
 
-            return response
+        return response
 
 
 class SyncableSignatureClient(SignatureClient):

--- a/assemblyline_v4_service/updater/client.py
+++ b/assemblyline_v4_service/updater/client.py
@@ -57,15 +57,20 @@ class SyncableBadlistClient(BadlistClient):
             # Find the IDs that don't exist at this source anymore and remove the source from the source list
             for missing_id in existing_ids - current_ids:
                 missing_item: BadlistModel = self.datastore.badlist.get(missing_id)
+                original_sources = missing_item.sources
                 missing_item.sources = [
                     s
                     for s in missing_item.sources
                     if not (s.type == "external" and s.name == source)
                 ]
 
-                # If there are no more sources to back this item, then disable it
+                # If there are no more sources to back this item, then disable it but leave at least one source
                 if not missing_item.sources:
                     missing_item.enabled = False
+                    missing_item.sources = original_sources[:1]
+
+                # Update the last updated time
+                missing_item.updated = "NOW"
 
                 # Update missing item with latest changes
                 self.datastore.badlist.save(missing_id, missing_item)
@@ -139,15 +144,20 @@ class SyncableSafelistClient(SafelistClient):
             # Find the IDs that don't exist at this source anymore and remove the source from the source list
             for missing_id in existing_ids - current_ids:
                 missing_item: SafelistModel = self.datastore.safelist.get(missing_id)
+                original_sources = missing_item.sources
                 missing_item.sources = [
                     s
                     for s in missing_item.sources
                     if not (s.type == "external" and s.name == source)
                 ]
 
-                # If there are no more sources to back this item, then disable it
+                # If there are no more sources to back this item, then disable it but leave at least one source
                 if not missing_item.sources:
                     missing_item.enabled = False
+                    missing_item.sources = original_sources[:1]
+
+                # Update the last updated time
+                missing_item.updated = "NOW"
 
                 # Update missing item with latest changes
                 self.datastore.safelist.save(missing_id, missing_item)

--- a/assemblyline_v4_service/updater/client.py
+++ b/assemblyline_v4_service/updater/client.py
@@ -104,7 +104,7 @@ def hashlist_add_update_many(client: Union[SyncableBadlistClient, SyncableSafeli
         def update_response(r: Dict[str, Any]):
             # Response has to be in the same format, but show the accumulation of batches
             response["success"]: int = response["success"] + r["success"]
-            response["errors"]: bool = response["errors"] and r["errors"]
+            response["errors"]: bool = response["errors"] or r["errors"]
 
         # Split up data into batches to avoid server timeouts handling requests
         batch_num = 0

--- a/assemblyline_v4_service/updater/client.py
+++ b/assemblyline_v4_service/updater/client.py
@@ -259,6 +259,16 @@ class SyncableSignatureClient(SignatureClient):
 class UpdaterClient(object):
     def __init__(self, datastore) -> None:
         self.datastore = datastore
+        self._sync = False
         self.badlist = SyncableBadlistClient(datastore)
         self.safelist = SyncableSafelistClient(datastore)
         self.signature = SyncableSignatureClient(datastore)
+
+    @property
+    def sync(self):
+        return self._sync
+
+    @sync.setter
+    def sync(self, value: bool):
+        # Set sync state across clients
+        self.badlist.sync = self.safelist.sync = self.signature.sync = self._sync = value

--- a/assemblyline_v4_service/updater/client.py
+++ b/assemblyline_v4_service/updater/client.py
@@ -8,7 +8,7 @@ from assemblyline_core.badlist_client import BadlistClient
 from assemblyline_core.safelist_client import SafelistClient
 from assemblyline_core.signature_client import SignatureClient
 
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 SIGNATURE_UPDATE_BATCH = int(os.environ.get('SIGNATURE_UPDATE_BATCH', '1000'))
 
@@ -43,8 +43,8 @@ def hashlist_add_update_many(client: Union[SyncableBadlistClient, SyncableSafeli
     if not data:
         return {"success": 0, "errors": False}
 
-    current_ids = set()
-    source = None
+    current_ids: Set[str] = set()
+    source: Optional[str] = None
 
     # Iterate over the list of signatures given
     for i, d in enumerate(data):
@@ -62,7 +62,7 @@ def hashlist_add_update_many(client: Union[SyncableBadlistClient, SyncableSafeli
         data[i] = d
 
     if client.sync:
-        # Get the list of items that currently existing in the system for the source
+        # Get the list of items that currently exists in the system for the source
         existing_ids = set(
             [
                 i["id"]
@@ -73,7 +73,8 @@ def hashlist_add_update_many(client: Union[SyncableBadlistClient, SyncableSafeli
         )
 
         # Find the IDs that don't exist at this source anymore and remove the source from the source list
-        for missing_id in existing_ids - current_ids:
+        missing_ids = existing_ids - current_ids
+        for missing_id in missing_ids:
             missing_item = collection.get(missing_id)
             original_sources = missing_item.sources
             missing_item.sources = [
@@ -212,4 +213,7 @@ class UpdaterClient(object):
     @sync.setter
     def sync(self, value: bool):
         # Set sync state across clients
-        self.badlist.sync = self.safelist.sync = self.signature.sync = self._sync = value
+        self.badlist.sync = value
+        self.safelist.sync = value
+        self.signature.sync = value
+        self._sync = value

--- a/assemblyline_v4_service/updater/updater.py
+++ b/assemblyline_v4_service/updater/updater.py
@@ -371,8 +371,8 @@ class ServiceUpdater(ThreadedCoreBase):
                     source = source_obj.as_primitives()
                     uri: str = source['uri']
                     default_classification = source.get('default_classification', classification.UNRESTRICTED)
-                    # Enable signature syncing if the source specifies it
-                    self.client.signature.sync = source.get('sync', False)
+                    # Enable syncing if the source specifies it
+                    self.client.sync = source.get('sync', False)
 
                     try:
                         self.push_status("UPDATING", "Pulling..")

--- a/pipelines/azure-tests.yaml
+++ b/pipelines/azure-tests.yaml
@@ -11,6 +11,15 @@ variables:
   BRANCH_NAME: $[coalesce(variables['System.PullRequest.SourceBranch'], variables['System.PullRequest.TargetBranch'], replace(variables['Build.SourceBranch'], 'refs/heads/', ''))]
 
 resources:
+  containers:
+    - container: elasticsearch
+      image: cccs/elasticsearch:8.10.2
+      env:
+        ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+        DISCOVERY_TYPE: "single-node"
+        ELASTIC_PASSWORD: "devpass"
+      ports:
+        - 9200:9200
   repositories:
     - repository: assemblyline-base
       type: github
@@ -34,6 +43,8 @@ jobs:
         Python3_12:
           python.version: "3.12"
     timeoutInMinutes: 10
+    services:
+      elasticsearch: elasticsearch
 
     steps:
       - task: UsePythonVersion@0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,61 @@
+"""
+Pytest configuration file, setup global pytest fixtures and functions here.
+"""
+import os
+import pytest
+
+from assemblyline.common import forge
+from assemblyline.datastore.helper import AssemblylineDatastore
+from assemblyline.datastore.store import ESStore
+
+original_skip = pytest.skip
+
+# Check if we are in an unattended build environment where skips won't be noticed
+IN_CI_ENVIRONMENT = any(indicator in os.environ for indicator in
+                        ['CI', 'BITBUCKET_BUILD_NUMBER', 'AGENT_JOBSTATUS'])
+
+
+def skip_or_fail(message):
+    """Skip or fail the current test, based on the environment"""
+    if IN_CI_ENVIRONMENT:
+        pytest.fail(message)
+    else:
+        original_skip(message)
+
+
+# Replace the built in skip function with our own
+pytest.skip = skip_or_fail
+
+
+@pytest.fixture(scope='session')
+def config():
+    config = forge.get_config()
+    config.logging.log_level = 'INFO'
+    config.logging.log_as_json = False
+    config.core.metrics.apm_server.server_url = None
+    config.core.metrics.export_interval = 1
+    config.datastore.archive.enabled = True
+    return config
+
+
+@pytest.fixture(scope='module')
+def datastore_connection(config):
+    store = ESStore(config.datastore.hosts)
+    ret_val = store.ping()
+    if not ret_val:
+        pytest.skip("Could not connect to datastore")
+    return AssemblylineDatastore(store)
+
+
+@pytest.fixture(scope='module')
+def clean_datastore(datastore_connection: AssemblylineDatastore):
+    for name in datastore_connection.ds.get_models():
+        datastore_connection.get_collection(name).wipe()
+    return datastore_connection
+
+
+@pytest.fixture(scope='function')
+def function_clean_datastore(datastore_connection: AssemblylineDatastore):
+    for name in datastore_connection.ds.get_models():
+        datastore_connection.get_collection(name).wipe()
+    return datastore_connection

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+    environment:
+      - xpack.security.enabled=true
+      - discovery.type=single-node
+      - logger.level=WARN
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - ELASTIC_PASSWORD=devpass
+    ports:
+      - "9200:9200"

--- a/test/test_updater/test_client.py
+++ b/test/test_updater/test_client.py
@@ -1,4 +1,3 @@
-
 import random
 import pytest
 

--- a/test/test_updater/test_client.py
+++ b/test/test_updater/test_client.py
@@ -1,0 +1,80 @@
+
+import random
+import pytest
+
+from assemblyline.odm.random_data import create_badlists, create_safelists, create_signatures, wipe_badlist, wipe_safelist, wipe_signatures
+from assemblyline_v4_service.updater.client import UpdaterClient
+
+
+@pytest.fixture(scope="module")
+def client(datastore_connection):
+    try:
+        create_badlists(datastore_connection)
+        create_safelists(datastore_connection)
+        create_signatures(datastore_connection)
+        yield UpdaterClient(datastore_connection)
+    finally:
+        wipe_badlist(datastore_connection)
+        wipe_safelist(datastore_connection)
+        wipe_signatures(datastore_connection)
+
+
+@pytest.mark.parametrize("hashlist", ["badlist", "safelist"])
+def test_hashlist_sync(client, hashlist):
+    hashlist_collection = getattr(client.datastore, hashlist)
+
+    # Pick an arbitrary source name fron the hashlist collection
+    SOURCE_NAME = random.choice(list(hashlist_collection.facet("sources.name",
+                                                               query="sources.type:external AND enabled:true").keys()))
+
+    # Get the set of items that are currently enabled in the test source
+    items = [
+        i
+        for i in hashlist_collection.stream_search(
+            query=f"sources.name:{SOURCE_NAME} AND enabled:true",
+            fl="id,sources")
+    ]
+
+    # Get a single item to be used during update
+    update_id = items.pop(0).id
+    update_item = hashlist_collection.get(update_id)
+
+    # Turn on syncing with the client
+    client.sync = True
+
+    # Perform update with no items found in source on update (this isn't allowed and will result in zero changes)
+    assert getattr(client, hashlist).add_update_many(data=[]) == {"success": 0, "errors": False}
+
+    # Perform updates with a single item found in source
+    assert getattr(client, hashlist).add_update_many(data=[update_item]) == {"success": 1, "errors": False}
+
+    # Ensure changes to items are as expected
+    for item in items:
+        item = hashlist_collection.get(item.id)
+        if item.enabled:
+            # If the item is still enabled, then we have to ensure the test source was removed from the source list
+            assert all([not (s.name == SOURCE_NAME and s.type == 'external') for s in item.sources])
+        else:
+            # If the item has been disabled, then we have to ensure there is only one source left in the source list
+            assert len(item.sources) == 1
+
+
+def test_signature_sync(client):
+    # Get the set of YARA signatures that are currently DEPLOYED in the YAR_SAMPLE source
+    SOURCE_NAME = "YAR_SAMPLE"
+    SIG_TYPE = "yara"
+    signature_ids = [
+        i.id
+        for i in client.datastore.signature.stream_search(
+            query=f"source:{SOURCE_NAME} AND type:{SIG_TYPE} AND status:DEPLOYED",
+            fl="id")
+    ]
+
+    # Turn on syncing with the client
+    client.sync = True
+
+    # Simulate if all the signatures from the source is missing on update
+    client.signature.add_update_many(SOURCE_NAME, SIG_TYPE, data=[])
+
+    # Assert that all signatures that were previously DEPLOYED are now all DISABLED
+    assert all([client.datastore.signature.get(id).status == "DISABLED" for id in signature_ids])


### PR DESCRIPTION
The idea would be if there is no source to further stake its reputation of a item to be blocked/safelisted, then we'll disable that item from our lists.

This will allow users to re-enable items should they choose to and will allow downstream systems to be able to synchronize changes (ie. Replay).