### PR TITLE
Wrap OCR config update in a function that will be called by the service base

### DIFF
--- a/assemblyline_v4_service/common/base.py
+++ b/assemblyline_v4_service/common/base.py
@@ -19,6 +19,7 @@ from assemblyline.odm.messages.task import Task as ServiceTask
 from assemblyline_v4_service.common import helper
 from assemblyline_v4_service.common.api import PrivilegedServiceAPI, ServiceAPI
 from assemblyline_v4_service.common.ontology_helper import OntologyHelper
+from assemblyline_v4_service.common.ocr import update_ocr_config
 from assemblyline_v4_service.common.request import ServiceRequest
 from assemblyline_v4_service.common.task import Task
 
@@ -83,6 +84,10 @@ class ServiceBase:
         self.update_check_time: float = 0.0
         self.rules_hash: str = None
         self.signatures_meta: dict = {}
+
+        # OCR-related
+        if self.config.get('ocr'):
+            update_ocr_config(self.config['ocr'])
 
     @property
     def api_interface(self):

--- a/test/test_common/test_ocr.py
+++ b/test/test_common/test_ocr.py
@@ -3,10 +3,11 @@ from test.test_common import TESSERACT_LIST
 
 import pytest
 
-from assemblyline_v4_service.common.ocr import ocr_detections, detections
+from assemblyline_v4_service.common.ocr import ocr_detections, detections, update_ocr_config
 
 @pytest.mark.skipif(len(TESSERACT_LIST) < 1, reason="Requires tesseract-ocr apt package")
 def test_ocr_detections():
+    update_ocr_config()
     file_path = os.path.join(os.path.dirname(__file__), "b32969aa664e3905c20f865cdd7b921f922678f5c3850c78e4c803fbc1757a8e")
     assert ocr_detections(file_path) == {
         'ransomware': [
@@ -27,6 +28,8 @@ def test_ocr_detections():
 
 
 def test_detections():
+    update_ocr_config()
+
     # No detection
     assert detections("blah") == {}
 


### PR DESCRIPTION
Because of the nature of how we start up privileged and non-privileged services, we could end up in race conditions where the service manifest hasn't been created yet and so we only load the defaults on module load.

This change explicitly calls for an update when we're instantiating the service base and we'll pass forward the configuration we've already loaded at the time of instantiation.