### PR TITLE
Obtain file requirements directly from manifest for privileged services

### DIFF
--- a/pipelines/azure-tests.yaml
+++ b/pipelines/azure-tests.yaml
@@ -13,11 +13,12 @@ variables:
 resources:
   containers:
     - container: elasticsearch
-      image: cccs/elasticsearch:8.10.2
+      image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
       env:
-        ES_JAVA_OPTS: "-Xms512m -Xmx512m"
-        DISCOVERY_TYPE: "single-node"
-        ELASTIC_PASSWORD: "devpass"
+        xpack.security.enabled: true
+        discovery.type: single-node
+        ES_JAVA_OPTS: "-Xms256m -Xmx512m"
+        ELASTIC_PASSWORD: devpass
       ports:
         - 9200:9200
     - container: redis


### PR DESCRIPTION
Related to: https://github.com/CybercentreCanada/assemblyline/issues/349

This change should mimic the same behaviour for unprivileged services which respect the `file_required` configuration for a service.